### PR TITLE
fix @oclif/color dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "bugs": "https://github.com/oclif/plugin-not-found/issues",
   "dependencies": {
-    "@oclif/color": "^0.0.0",
+    "@oclif/color": "^0.x",
     "@oclif/command": "^1.6.0",
     "cli-ux": "^4.9.0",
     "fast-levenshtein": "^2.0.6",


### PR DESCRIPTION
Fixes #37, showing the same issue described in [this](https://github.com/oclif/plugin-plugins/issues/86#issuecomment-606356298) comment - the `^0.0.0` range doesn't contain `0.1.0`, so it's not picking up the fixed version. In my yarn workspace:

```
> require('@oclif/plugin-not-found')
TypeError: Cannot read property 'dim' of undefined
    at Object.<anonymous> (/Users/david/projects/zapier/platform/node_modules/@oclif/color/lib/index.js:10:86)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
    at Module.require (internal/modules/cjs/loader.js:636:17)
    at require (internal/modules/cjs/helpers.js:20:18)
```