### PR TITLE
fix: split suggested command from passed command to get varargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /lib
 /node_modules
 /tmp
+/.idea
+/.vscode

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "@oclif/color": "^1.0.4",
     "@oclif/core": "^2.8.0",
-    "fast-levenshtein": "^3.0.0",
-    "lodash": "^4.17.21"
+    "fast-levenshtein": "^3.0.0"
   },
   "devDependencies": {
     "@oclif/config": "^1.18.8",
@@ -26,12 +25,10 @@
     "@oclif/test": "^1.2.9",
     "@types/chai": "^4.3.5",
     "@types/fast-levenshtein": "^0.0.2",
-    "@types/lodash": "^4.14.194",
     "@types/mocha": "^8.2.3",
     "@types/node": "^15.14.9",
     "@types/supports-color": "^8.1.1",
     "chai": "^4.3.7",
-    "chalk": "^5.2.0",
     "eslint": "^7.32.0",
     "eslint-config-oclif": "^4",
     "eslint-config-oclif-typescript": "^1.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {Hook, toConfiguredId, ux} from '@oclif/core'
 import * as Levenshtein from 'fast-levenshtein'
 
 export const closest = (target: string, possibilities: string[]): string =>
-  possibilities.map(id => ({id, distance: Levenshtein.get(target, id)})).sort((a, b) => a.distance - b.distance)[0]?.id ?? ''
+  possibilities.map(id => ({id, distance: Levenshtein.get(target, id, {useCollator: true})})).sort((a, b) => a.distance - b.distance)[0]?.id ?? ''
 
 const hook: Hook.CommandNotFound = async function (opts) {
   const hiddenCommandIds = new Set(opts.config.commands.filter(c => c.hidden).map(c => c.id))

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,14 +29,16 @@ const hook: Hook.CommandNotFound = async function (opts) {
 
   let response = ''
   try {
-    response = await ux.prompt(`Did you mean ${color.blueBright(readableSuggestion)}? [y/n]`, {timeout: 4900})
+    response = await ux.prompt(`Did you mean ${color.blueBright(readableSuggestion)}? [y/n]`, {timeout: 10_000})
   } catch (error) {
     this.log('')
     this.debug(error)
   }
 
   if (response === 'y') {
-    const argv = opts.argv || process.argv.slice(3, process.argv.length)
+    // this will split the original command from the suggested replacement, and gather the remaining args as varargs to help with situations like:
+    // confit set foo-bar -> confit:set:foo-bar -> config:set:foo-bar -> config:set foo-bar
+    const argv = opts.argv?.length ? opts.argv : opts.id.split(':').slice(suggestion.split(':').length)
     return this.config.runCommand(suggestion, argv)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import {color} from '@oclif/color'
-import {ux, Hook, toConfiguredId} from '@oclif/core'
+import {Hook, toConfiguredId, ux} from '@oclif/core'
 import * as Levenshtein from 'fast-levenshtein'
-import * as _ from 'lodash'
 
 const hook: Hook.CommandNotFound = async function (opts) {
   const hiddenCommandIds = new Set(opts.config.commands.filter(c => c.hidden).map(c => c.id))
@@ -12,7 +11,13 @@ const hook: Hook.CommandNotFound = async function (opts) {
 
   if (commandIDs.length === 0) return
   function closest(cmd: string): string {
-    return _.minBy(commandIDs, c => Levenshtein.get(cmd, c))!
+    // we'll use this array to keep track of which key is the closest to the users entered value.
+    // keys closer to the index 0 will be a closer guess than keys indexed further from 0
+    // an entry at 0 would be a direct match, an entry at 1 would be a single character off, etc.
+    const index: string[] = []
+    // eslint-disable-next-line no-return-assign
+    commandIDs.map(id => (index[Levenshtein.get(cmd, id)] = id))
+    return index.find(item => item !== undefined) ?? ''
   }
 
   let binHelp = `${opts.config.bin} help`

--- a/test/closest.test.ts
+++ b/test/closest.test.ts
@@ -1,0 +1,37 @@
+import {closest} from '../src'
+import {expect} from 'chai'
+
+describe('closest', () => {
+  const possibilities = ['abc', 'def', 'ghi', 'jkl', 'jlk']
+  it('exact match', () => {
+    expect(closest('abc', possibilities)).to.equal('abc')
+  })
+
+  it('case mistake', () => {
+    expect(closest('aBc', possibilities)).to.equal('abc')
+  })
+
+  it('case match one letter', () => {
+    expect(closest('aZZ', possibilities)).to.equal('abc')
+  })
+
+  it('one letter different mistake', () => {
+    expect(closest('ggi', possibilities)).to.equal('ghi')
+  })
+
+  it('two letter different mistake', () => {
+    expect(closest('gki', possibilities)).to.equal('ghi')
+  })
+
+  it('extra letter', () => {
+    expect(closest('gkui', possibilities)).to.equal('ghi')
+  })
+
+  it('two letter different mistake with close neighbor', () => {
+    expect(closest('jpp', possibilities)).to.equal('jkl')
+  })
+
+  it('no possibilities gives empty string', () => {
+    expect(closest('jpp', [])).to.equal('')
+  })
+})

--- a/test/hooks/not-found.test.ts
+++ b/test/hooks/not-found.test.ts
@@ -22,6 +22,19 @@ describe('command_not_found', () => {
   })
 
   test
+  .stub(ux, 'prompt', yes)
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  .stub(process, 'argv', ['username'])
+  .stdout()
+  .stderr()
+  .hook('command_not_found', {id: 'commans get'})
+  .end('runs hook with suggested command on yes with varargs passed', (ctx: any) => {
+    expect(ctx.stderr).to.be.contain('Warning: commans get is not a @oclif/plugin-not-found command.\n')
+    expect(ctx.stdout).to.match(/commands.+?\n.*?help/)
+  })
+
+  test
   .stderr()
   .stub(ux, 'prompt', yes)
   .hook('command_not_found', {id: 'commans', argv: ['foo', '--bar', 'baz']})

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,10 +462,21 @@
     node-gyp "^8.2.0"
     read-package-json-fast "^2.0.1"
 
-"@oclif/color@^1.0.3", "@oclif/color@^1.0.4":
+"@oclif/color@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@oclif/color/-/color-1.0.4.tgz#07e54e3bd76a29e77d6ad71aef33222fe4f728e7"
   integrity sha512-HEcVnSzpQkjskqWJyVN3tGgR0H0F8GrBmDjgQ1N0ZwwktYa4y9kfV07P/5vt5BjPXNyslXHc4KAO8Bt7gmErCA==
+  dependencies:
+    ansi-styles "^4.2.1"
+    chalk "^4.1.0"
+    strip-ansi "^6.0.1"
+    supports-color "^8.1.1"
+    tslib "^2"
+
+"@oclif/color@^1.0.4":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@oclif/color/-/color-1.0.5.tgz#09da86db0cdda7601f77038d3c573e3d041a19f9"
+  integrity sha512-CeUDnzGOt3G7k6KJolTueTMYfJnU/zc6MouwF3sgL+7lnrwTiLaLwQ384EVFtUaIlRHNA0WifGh6FHKc8jqw2g==
   dependencies:
     ansi-styles "^4.2.1"
     chalk "^4.1.0"
@@ -836,7 +847,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash@*", "@types/lodash@^4.14.194":
+"@types/lodash@*":
   version "4.14.194"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
   integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
@@ -1416,11 +1427,6 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
-
-chalk@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
-  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
 
 chardet@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
@W-12459598@

goes from 
```
➜  plugin-telemetry git:(main) ✗ 
 ➜  sf confit get target-dev-hub
 ›   Warning: confit get target-dev-hub is not a sf command.
Did you mean config get? [y/n]: y
Error (1): You must provide one or more configuration variables to get. Run "sf config list" to see the configuration variables you've previously set.
```

to
```
 ➜  sf confit get target-dev-hub             
 ›   Warning: confit get target-dev-hub is not a sf command.
Did you mean config get? [y/n]: y
Get Config
===============================
| Name           Value  Success 
| ────────────── ────── ─────── 
| target-dev-hub DevHub true    
```

and with improved accuracy 
before
```
 ➜  sf get confit target-org    
 ›   Warning: get confit target-org is not a sf command.
Did you mean dev configure repo? [y/n]: n
```
after

```
 ➜  sf get confit target-org    
 ›   Warning: get confit target-org is not a sf command.
Did you mean config get? [y/n]: n

```
