### PR TITLE
fix: identify when the command is meant to be 'help'

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@
 &#34;did you mean&#34; for oclif
 
 [![Version](https://img.shields.io/npm/v/@oclif/plugin-not-found.svg)](https://npmjs.org/package/@oclif/plugin-not-found)
-[![CircleCI](https://circleci.com/gh/oclif/plugin-not-found/tree/main.svg?style=svg)](https://circleci.com/gh/oclif/plugin-not-found/tree/main)
-[![Appveyor CI](https://ci.appveyor.com/api/projects/status/github/oclif/plugin-not-found?branch=main&svg=true)](https://ci.appveyor.com/project/heroku/plugin-not-found/branch/main)
 [![Known Vulnerabilities](https://snyk.io/test/npm/@oclif/plugin-not-found/badge.svg)](https://snyk.io/test/npm/@oclif/plugin-not-found)
 [![Downloads/week](https://img.shields.io/npm/dw/@oclif/plugin-not-found.svg)](https://npmjs.org/package/@oclif/plugin-not-found)
 [![License](https://img.shields.io/npm/l/@oclif/plugin-not-found.svg)](https://github.com/oclif/plugin-not-found/blob/main/package.json)
+
+## Developing
+
+This plugin works as a hook, so it won't "fire" just from being linked (ex: `plugins link .`)
+
+To test changes using a CLI that already contains plugin-not-found, build this and copy this repo's `lib/index.js` over your CLI's equivalent.
+
+ex: `~/.local/share/sf/client/current/node_modules/@oclif/plugin-not-found/lib/index.js`

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ const hook: Hook.CommandNotFound = async function (opts) {
 
   // alter the suggestion in the help scenario so that help is the first command
   // otherwise the user will be presented 'did you mean 'help'?' instead of 'did you mean "help <command>"?'
-  let suggestion = /:?help:?/.test(opts.id) ? ['help', closest(opts.id.replace(/:?help:?/, ''), commandIDs)].join(':') : closest(opts.id, commandIDs)
+  let suggestion = /:?help:?/.test(opts.id) ? ['help', ...opts.id.split(':').filter(cmd => cmd !== 'help')].join(':') : closest(opts.id, commandIDs)
 
   const readableSuggestion = toConfiguredId(suggestion, this.config)
   const originalCmd = toConfiguredId(opts.id, this.config)

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,9 @@ const hook: Hook.CommandNotFound = async function (opts) {
     binHelp = `${binHelp} ${idSplit[0]}`
   }
 
-  const suggestion = closest(opts.id, commandIDs)
+  // alter the suggestion in the help scenario so that help is the first command
+  // otherwise the user will be presented 'did you mean 'help'?' instead of 'did you mean "help <command>"?'
+  let suggestion = /:?help:?/.test(opts.id) ? ['help', closest(opts.id.replace(/:?help:?/, ''), commandIDs)].join(':') : closest(opts.id, commandIDs)
 
   const readableSuggestion = toConfiguredId(suggestion, this.config)
   const originalCmd = toConfiguredId(opts.id, this.config)
@@ -38,7 +40,16 @@ const hook: Hook.CommandNotFound = async function (opts) {
   if (response === 'y') {
     // this will split the original command from the suggested replacement, and gather the remaining args as varargs to help with situations like:
     // confit set foo-bar -> confit:set:foo-bar -> config:set:foo-bar -> config:set foo-bar
-    const argv = opts.argv?.length ? opts.argv : opts.id.split(':').slice(suggestion.split(':').length)
+    let argv = opts.argv?.length ? opts.argv : opts.id.split(':').slice(suggestion.split(':').length)
+
+    if (suggestion.startsWith('help:')) {
+      // the args are the command/partial command you need help for (package:version)
+      // we created the suggestion variable to start with "help" so slice the first entry
+      argv = [...suggestion.split(':').slice(1), ...argv]
+      // the command is just the word "help"
+      suggestion = 'help'
+    }
+
     return this.config.runCommand(suggestion, argv)
   }
 


### PR DESCRIPTION
@W-13649156@
https://github.com/forcedotcom/cli/issues/2240

this could potentially be wholly fixed in the tax-free code in oclif/core

```bash
 ➜  sf package help
 ›   Warning: package help is not a sf command.
Did you mean help package? [y/n]: y
Create a package.

USAGE
  $ sf package COMMAND
```

```bash
 ➜  sf package help list                         
 ›   Warning: package help list is not a sf command.
Did you mean help package list? [y/n]: y
List all packages in the Dev Hub org.

USAGE
  $ sf package list -v <value> [--json] [--api-version <value>] [--verbose]
```