### PR TITLE
chore: bump version of the dependencies that fixed lodash vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^18",
-    "@oclif/plugin-commands": "^3",
+    "@oclif/plugin-commands": "^3.3.3",
     "@oclif/plugin-help": "^6",
     "@oclif/prettier-config": "^0.2.1",
     "@oclif/test": "^3.2.13",
@@ -29,7 +29,7 @@
     "husky": "^9",
     "lint-staged": "^15",
     "mocha": "^10.4.0",
-    "oclif": "^4.10.7",
+    "oclif": "^4.10.9",
     "prettier": "^3.2.5",
     "shx": "^0.3.4",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
Fixes #626 

Bumped the versions of the dependencies that fixed lodash vulnerability