### PR TITLE
fix: skip prompt if not attached to a TTY

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,3 +13,25 @@ jobs:
   windows-unit-tests:
     needs: linux-unit-tests
     uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@main
+  sf-integration-tests:
+    needs: linux-unit-tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install sf
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: npm install -g @salesforce/cli@nightly --omit=dev
+          timeout_minutes: 60
+      - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
+      - run: yarn build
+      - name: Run tests
+        run: yarn test:integration:sf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,11 @@ jobs:
         with:
           max_attempts: 3
           retry_wait_seconds: 60
-          command: npm install -g @salesforce/cli@nightly --omit=dev
+          command: npm install -g @salesforce/cli@nightly
           timeout_minutes: 60
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - run: yarn build
       - name: Run tests
         run: yarn test:integration:sf
+        env:
+          SF_DISABLE_TELEMETRY: true

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/fast-levenshtein": "^0.0.4",
     "@types/mocha": "^10.0.9",
     "@types/node": "^18",
+    "@types/shelljs": "0.8.15",
     "@types/sinon": "^17.0.3",
     "chai": "^4.5.0",
     "commitlint": "^19",
@@ -32,6 +33,7 @@
     "mocha": "^10.8.2",
     "oclif": "^4.17.46",
     "prettier": "^3.5.3",
+    "shelljs": "0.9.2",
     "shx": "^0.4.0",
     "sinon": "^18.0.1",
     "ts-node": "^10.9.2",
@@ -71,6 +73,7 @@
     "prepare": "husky && yarn build",
     "pretest": "yarn build --noEmit && tsc -p test --noEmit",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
+    "test:integration:sf": "mocha \"test/**/sf.integration.ts\"",
     "version": "oclif readme && git add README.md"
   },
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,9 @@ const hook: Hook.CommandNotFound = async function (opts) {
   const originalCmd = toConfiguredId(opts.id, this.config)
   this.warn(`${yellow(originalCmd)} is not a ${opts.config.bin} command.`)
 
-  const response = await utils.getConfirmation(readableSuggestion).catch(() => false)
+  // Skip prompt if not in interactive terminal.
+  const response =
+    process.stdin.isTTY === true ? await utils.getConfirmation(readableSuggestion).catch(() => false) : false
 
   if (response) {
     // this will split the original command from the suggested replacement, and gather the remaining args as varargs to help with situations like:

--- a/test/hooks/not-found.test.ts
+++ b/test/hooks/not-found.test.ts
@@ -25,22 +25,6 @@ describe('command_not_found', () => {
     process.stdin.isTTY = isTTYval
   })
 
-  it('should not prompt if not attached to a TTY', async () => {
-    sinon.stub(process, 'argv').returns([])
-    if (process.stdin.isTTY) {
-      sinon.stub(process.stdin, 'isTTY').value(false)
-    }
-
-    const startTime = Date.now()
-    const {error, stderr} = await runHook('command_not_found', {id: 'commans'})
-    const endTime = Date.now()
-
-    // the prompt times out after 10s, this assertion ensures the prompt never got rendered and the hook failed quickly
-    expect(endTime - startTime).to.be.lessThan(3000)
-    expect(stderr).to.contain('Warning: commans is not a @oclif/plugin-not-found command.\n')
-    expect(error?.message).to.contain('Run @oclif/plugin-not-found help for a list of available commands.')
-  })
-
   it('should run hook with suggested command on yes', async () => {
     sinon.stub(utils, 'getConfirmation').resolves(true)
     sinon.stub(process, 'argv').returns([])

--- a/test/hooks/not-found.test.ts
+++ b/test/hooks/not-found.test.ts
@@ -5,13 +5,31 @@ import sinon from 'sinon'
 import utils from '../../src/utils.js'
 
 describe('command_not_found', () => {
+  const isTTYval = process.stdin.isTTY
+
+  beforeEach(() => {
+    // stub if isTTY isn't undefined, otherwise set it to true (process.stdiin.isTTY is `undefined` in CI so mocha fails to stub it)
+    if (process.stdin.isTTY) {
+      sinon.stub(process.stdin, 'isTTY').value(true)
+    } else {
+      process.stdin.isTTY = true
+    }
+  })
+
   afterEach(() => {
     sinon.restore()
   })
 
+  after(() => {
+    // restore original isTTY value after all tests are done
+    process.stdin.isTTY = isTTYval
+  })
+
   it('should not prompt if not attached to a TTY', async () => {
     sinon.stub(process, 'argv').returns([])
-    sinon.stub(process.stdin, 'isTTY').set(() => false)
+    if (process.stdin.isTTY) {
+      sinon.stub(process.stdin, 'isTTY').value(false)
+    }
 
     const startTime = Date.now()
     const {error, stderr} = await runHook('command_not_found', {id: 'commans'})

--- a/test/hooks/not-found.test.ts
+++ b/test/hooks/not-found.test.ts
@@ -9,6 +9,20 @@ describe('command_not_found', () => {
     sinon.restore()
   })
 
+  it('should not prompt if not attached to a TTY', async () => {
+    sinon.stub(process, 'argv').returns([])
+    sinon.stub(process.stdin, 'isTTY').set(() => false)
+
+    const startTime = Date.now()
+    const {error, stderr} = await runHook('command_not_found', {id: 'commans'})
+    const endTime = Date.now()
+
+    // the prompt times out after 10s, this assertion ensures the prompt never got rendered and the hook failed quickly
+    expect(endTime - startTime).to.be.lessThan(3000)
+    expect(stderr).to.contain('Warning: commans is not a @oclif/plugin-not-found command.\n')
+    expect(error?.message).to.contain('Run @oclif/plugin-not-found help for a list of available commands.')
+  })
+
   it('should run hook with suggested command on yes', async () => {
     sinon.stub(utils, 'getConfirmation').resolves(true)
     sinon.stub(process, 'argv').returns([])

--- a/test/integration/sf.integration.ts
+++ b/test/integration/sf.integration.ts
@@ -1,0 +1,35 @@
+import {expect} from 'chai'
+import {stripVTControlCharacters} from 'node:util'
+import shelljs from 'shelljs'
+
+describe('sf CLI integration', () => {
+  before(() => {
+    const build = shelljs.exec('yarn build')
+    if (build.code !== 0) throw new Error('yarn build failed')
+    const link = shelljs.exec('sf plugins link --no-install')
+    if (link.code !== 0) throw new Error('sf plugins link failed')
+  })
+
+  after(() => {
+    const unlink = shelljs.exec('sf plugins unlink .')
+    if (unlink.code !== 0) throw new Error('sf plugins unlink failed')
+  })
+
+  it('should skip the prompt when not attached to a TTY and return 127', async () => {
+    const isTTYval: boolean | undefined = process.stdin.isTTY
+
+    if (isTTYval === true) {
+      process.stdin.isTTY = false
+    }
+
+    const startTime = Date.now()
+    const res = shelljs.exec('sf wat')
+    const endTime = Date.now()
+
+    expect(endTime - startTime).to.be.lessThan(1000)
+    expect(stripVTControlCharacters(res.stdout)).to.not.include('Did you mean')
+    expect(res.code).to.equal(127)
+
+    process.stdin.isTTY = isTTYval
+  })
+})

--- a/test/integration/sf.integration.ts
+++ b/test/integration/sf.integration.ts
@@ -6,6 +6,7 @@ describe('sf CLI integration', () => {
   before(() => {
     const build = shelljs.exec('yarn build')
     if (build.code !== 0) throw new Error('yarn build failed')
+
     const link = shelljs.exec('sf plugins link --no-install')
     if (link.code !== 0) throw new Error('sf plugins link failed')
   })
@@ -26,7 +27,7 @@ describe('sf CLI integration', () => {
     const res = shelljs.exec('sf wat')
     const endTime = Date.now()
 
-    expect(endTime - startTime).to.be.lessThan(1000)
+    expect(endTime - startTime).to.be.lessThan(3000)
     expect(stripVTControlCharacters(res.stdout)).to.not.include('Did you mean')
     expect(res.code).to.equal(127)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,6 +2210,14 @@
   resolved "https://registry.yarnpkg.com/@types/fast-levenshtein/-/fast-levenshtein-0.0.4.tgz#a16ff6607189edf08ac631e54b5774b0faf12d87"
   integrity sha512-tkDveuitddQCxut1Db8eEFfMahTjOumTJGPHmT9E7KUH+DkVq9WTpVvlfenf3S+uCBeu8j5FP2xik/KfxOEjeA==
 
+"@types/glob@~7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/http-cache-semantics@^4.0.2":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
@@ -2224,6 +2232,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/mocha@^10.0.9":
   version "10.0.9"
@@ -2255,6 +2268,14 @@
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
+
+"@types/shelljs@0.8.15":
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.15.tgz#22c6ab9dfe05cec57d8e6cb1a95ea173aee9fcac"
+  integrity sha512-vzmnCHl6hViPu9GNLQJ+DZFd6BQI2DBTUeOvYHqkWQLMfKAAQYMb/xAmZkTogZI/vqXHCWkqDRymDI5p0QTi5Q==
+  dependencies:
+    "@types/glob" "~7.2.0"
+    "@types/node" "*"
 
 "@types/sinon@^17.0.3":
   version "17.0.3"
@@ -6182,7 +6203,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@^0.9.2:
+shelljs@0.9.2, shelljs@^0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.9.2.tgz#a8ac724434520cd7ae24d52071e37a18ac2bb183"
   integrity sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==


### PR DESCRIPTION
Makes the `command_not_found` skip the `Did you mean?` prompt and fail fast if not attached to a TTY.
Without this change, running an invalid command in a spawned process would cause the caller to wait until the prompt timed out (10s).


### Testing instructions:

repro: run `printf "" | sf lala | node -e 'console.log(Boolean(process.stdin.isTTY))'` and see it hangs for 10s 

1. checkout this PR and link plugin to sf
2. run the piped commands mentioned above, see it fail fast
3. run `printf "" | sf lala` and verify exit code is `127`